### PR TITLE
custom MyGet build instructions

### DIFF
--- a/MyGet.bat
+++ b/MyGet.bat
@@ -1,0 +1,33 @@
+@echo Off
+set config=%1
+if "%config%" == "" (
+   set config=Release
+)
+
+set version=
+if not "%PackageVersion%" == "" (
+   set version=-Version %PackageVersion%
+)
+
+REM Package Restore
+%NuGet% install test\PUrify.Tests\packages.config -o %cd%\packages -NonInteractive
+if not "%errorlevel%"=="0" goto failure
+
+REM Build
+%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild test\PUrify.Tests\PUrify.Tests.csproj /p:Configuration="%config%" /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
+if not "%errorlevel%"=="0" goto failure
+
+REM Unit tests
+"%GallioEcho%" test\PUrify.Tests\bin\%config%\PUrify.Tests.dll
+if not "%errorlevel%"=="0" goto failure
+
+REM Package
+mkdir Build
+cmd /c %nuget% pack src\PUrify\PUrify.csproj -symbols -o Build -p Configuration=%config% %version%
+if not "%errorlevel%"=="0" goto failure
+
+:success
+exit 0
+
+:failure
+exit -1


### PR DESCRIPTION
This MyGet.bat contains custom build instructions and will execute the following flow:
1. restore NuGet packages for the test project
2. build the test project (and the referenced PUrify.csproj, this avoids building it twice in subsequent msbuild calls)
3. run unit tests
4. create the PUrify.nupkg and PUrify.symbols.nupkg
5. host the package on your MyGet feed
6. if the build source is configured to push the symbols package to symbolsource, myget will do that for you as well

Happy 2014! :)
