### PR TITLE
Fix failing mono tests

### DIFF
--- a/src/PUrify/Purify.cs
+++ b/src/PUrify/Purify.cs
@@ -52,6 +52,9 @@ namespace PUrify
 
         public static Uri Purify(this Uri uri)
         {
+            if (!uri.IsAbsoluteUri)
+                return uri;
+
             IPurifier purifier = null;
             if (isMono)
                 purifier = new PurifierMono();


### PR DESCRIPTION
I noticed two tests were failing in mono

PUrify.Tests.PurifyTest+ThePurifyMethod.CanHandleAbsoluteOrRelativeUri_RelativeGiven [FAIL]
PUrify.Tests.PurifyTest+ThePurifyMethod.CanHandleRelativeUri [FAIL]

Because inside the UriInfo we access the `.Host` property, This throws on mono but works fine in .NET.

I fixed this by making `.Purify()` on non absolute uri's (those explictly marked with UriKind.Relative) a noop.
