### PR TITLE
UriInfo sets port portion of url as path

### DIFF
--- a/src/PUrify/UriInfo.cs
+++ b/src/PUrify/UriInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -12,12 +13,20 @@ namespace Purify
 
         public UriInfo(Uri uri, string source)
         {
-            var fragPos = source.IndexOf("#");
-            var queryPos = source.IndexOf("?");
-            var start = source.IndexOf(uri.Host) + uri.Host.Length;
+            var fragPos = source.IndexOf("#", StringComparison.Ordinal);
+            var queryPos = source.IndexOf("?", StringComparison.Ordinal);
+            var start = source.IndexOf(uri.Host, StringComparison.Ordinal) + uri.Host.Length;
             var pathEnd = queryPos == -1 ? fragPos : queryPos;
+            
             if (pathEnd == -1)
                 pathEnd = source.Length + 1;
+
+            if (start < pathEnd - 1 && source[start] == ':')
+            {
+                var portLength = uri.Port.ToString(CultureInfo.InvariantCulture).Length;
+                start += portLength + 1;
+            }
+
             Path = queryPos > -1 ? source.Substring(start, pathEnd - start) : source.Substring(start);
 
             Query = fragPos > -1 ? source.Substring(queryPos, fragPos - queryPos) : null;

--- a/test/PUrify.Tests/UriInfoTest.cs
+++ b/test/PUrify.Tests/UriInfoTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Purify;
+using Should;
 using Xunit;
 
 namespace PUrify.Tests
@@ -17,6 +18,80 @@ namespace PUrify.Tests
             public void UriInfoWithoutPathDoesNotThrows()
             {
                 Assert.DoesNotThrow(() => new UriInfo(new Uri("http://localhost/"), "http://localhost/"));
+            }
+        }
+       
+        public class ConstructorWithNonDefaultPort
+        {
+            private UriInfo _uriInfo;
+            private Uri _uri;
+
+            public ConstructorWithNonDefaultPort()
+            {
+                var url = "http://localhost:1234/";
+                _uriInfo = new UriInfo(new Uri(url), url);
+                _uri = new Uri(url).Purify();
+            }
+
+            [Fact]
+            public void PortShouldNotBePartOfThePath()
+            {
+                _uriInfo.Path.ShouldEqual("/");
+            }
+            [Fact]
+            public void PortShouldNotHaveBeenLost()
+            {
+                _uri.Port.ShouldEqual(1234);
+            }
+        }
+        
+        public class ConstructorWithDefaultPort
+        {
+            private UriInfo _uriInfo;
+            private Uri _uri;
+
+            public ConstructorWithDefaultPort()
+            {
+                var url = "http://localhost:80/";
+                _uriInfo = new UriInfo(new Uri(url), url);
+                _uri = new Uri(url).Purify();
+            }
+
+            [Fact]
+            public void PortShouldNotBePartOfThePath()
+            {
+                _uriInfo.Path.ShouldEqual("/");
+            }
+            
+            [Fact]
+            public void PortShouldNotHaveBeenLost()
+            {
+                _uri.Port.ShouldEqual(80);
+            }
+        }
+
+        public class ConstructorWithPortAndUserNameInfo
+        {
+            private UriInfo _uriInfo;
+            private Uri _uri;
+
+            public ConstructorWithPortAndUserNameInfo()
+            {
+                var url = "http://mpdreamz:hasapassword@localhost:80/";
+                _uriInfo = new UriInfo(new Uri(url), url);
+                _uri = new Uri(url).Purify();
+            }
+
+            [Fact]
+            public void PortShouldNotBePartOfThePath()
+            {
+                _uriInfo.Path.ShouldEqual("/");
+            }
+            
+            [Fact]
+            public void UserInfoShouldNotHaveBeenLost()
+            {
+                _uri.UserInfo.ShouldEqual("mpdreamz:hasapassword");
             }
         }
     }


### PR DESCRIPTION
Fixes an issue where PathInfo makes `:port` part of the `.Path`.  

The .NET Uri implementations eats this up and so appears to be working but mono will start making urls starting with `:port/path` in the path causing the wrong urls to be hit.
