### PR TITLE
UriInfo class is improperly parsing URIs

### DIFF
--- a/src/PUrify/Purify.cs
+++ b/src/PUrify/Purify.cs
@@ -179,6 +179,13 @@ namespace Purify
                 var pathEnd = queryPos == -1 ? fragPos : queryPos;
                 if (pathEnd == -1)
                     pathEnd = source.Length + 1;
+
+                if (start < pathEnd - 1 && source[start] == ':')
+                {
+                    var portLength = uri.Port.ToString().Length;
+                    start += portLength + 1;
+                }
+
                 Path = queryPos > -1 ? source.Substring(start, pathEnd - start) : source.Substring(start);
                 Query = fragPos > -1
                     ? source.Substring(queryPos, fragPos - queryPos)

--- a/src/PUrify/Purify.cs
+++ b/src/PUrify/Purify.cs
@@ -180,8 +180,11 @@ namespace Purify
                 if (pathEnd == -1)
                     pathEnd = source.Length + 1;
                 Path = queryPos > -1 ? source.Substring(start, pathEnd - start) : source.Substring(start);
-                Query = fragPos > -1 ? source.Substring(queryPos, fragPos - queryPos) : source.Substring(queryPos);
-
+                Query = fragPos > -1
+                    ? source.Substring(queryPos, fragPos - queryPos)
+                    : queryPos > -1
+                        ? source.Substring(queryPos, (source.Length - queryPos))
+                        : null;
             }
         }
     }

--- a/test/PUrify.Tests/PurifyTest.cs
+++ b/test/PUrify.Tests/PurifyTest.cs
@@ -19,19 +19,19 @@ namespace PUrify.Tests
 
             public ThePurifyMethod()
             {
-                _uri = new Uri("http://www.myapi.com/%2F?Foo=Bar%2F#frag").Purify();
+                _uri = new Uri("http://www.myapi.com:1300/%2F?Foo=Bar%2F#frag").Purify();
             }
 
             [Fact]
             public void ToStringContainsEscapedSlashes()
             {
-                _uri.ToString().ShouldEqual("http://www.myapi.com/%2F?Foo=Bar%2F#frag");
+                _uri.ToString().ShouldEqual("http://www.myapi.com:1300/%2F?Foo=Bar%2F#frag");
             }
 
             [Fact]
             public void AbsoluteUriContainsEscapedSlashes()
             {
-                _uri.AbsoluteUri.ShouldEqual("http://www.myapi.com/%2F?Foo=Bar%2F#frag");
+                _uri.AbsoluteUri.ShouldEqual("http://www.myapi.com:1300/%2F?Foo=Bar%2F#frag");
             }
 
             [Fact]
@@ -56,6 +56,12 @@ namespace PUrify.Tests
             public void UriFragmentIsProperlySet()
             {
                 _uri.Fragment.ShouldEqual("#frag");
+            }
+
+            [Fact]
+            public void PortIsProperlySet()
+            {
+                this._uri.Port.ShouldEqual(1300);
             }
 
             [Fact]

--- a/test/PUrify.Tests/PurifyTest.cs
+++ b/test/PUrify.Tests/PurifyTest.cs
@@ -57,6 +57,13 @@ namespace PUrify.Tests
             {
                 _uri.Fragment.ShouldEqual("#frag");
             }
+
+            [Fact]
+            public void UriWithoutQueryString_CanBeParsed()
+            {
+                var uri = new Uri("http://www.myapi.com/%2F").Purify();
+                uri.ToString().ShouldEqual("http://www.myapi.com/%2F");
+            }
         }
 
     }


### PR DESCRIPTION
I initially made a [pull request](https://github.com/elastic/elasticsearch-net/pull/1651) to the [elasticsearch-net](https://github.com/elastic/elasticsearch-net) project to fix this but then realized that Purify was its own project.

This pull request is to primarily fix how URIs without query strings are parsed. It currently breaks with a `System.ArgumentOutOfRangeException : StartIndex cannot be less than zero.` exception.

 It also handles removing the port number from the purified URI path.