### PR TITLE
This adds support for travis and fixes GetHashCode on mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: csharp
+mono:
+    - latest
+    - 3.12.0
+    - 3.10.0
+solution: PUrify.sln
+install:
+    - nuget restore PUrify.sln
+    - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
+script:
+    - xbuild /p:Configuration=Release PUrify.sln
+    - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./test/PUrify.Tests/bin/Release/PUrify.Tests.dll

--- a/src/PUrify/Purify.cs
+++ b/src/PUrify/Purify.cs
@@ -154,11 +154,11 @@ namespace Purify
             public Uri Purify(Uri uri)
             {
                 var source = (string)mono_sourceField.GetValue(uri);
-                mono_cachedToStringField.SetValue(uri, source);
-                mono_cachedAbsoluteUriField.SetValue(uri, source);
+                mono_cachedToStringField.SetValue(uri, source ?? string.Empty);
+                mono_cachedAbsoluteUriField.SetValue(uri, source ?? string.Empty);
                 var uriInfo = new UriInfo(uri, source);
-                mono_pathField.SetValue(uri, uriInfo.Path);
-                mono_queryField.SetValue(uri, uriInfo.Query);
+                mono_pathField.SetValue(uri, uriInfo.Path ?? string.Empty);
+                mono_queryField.SetValue(uri, uriInfo.Query ?? string.Empty);
                 return uri;
             }
         }

--- a/test/PUrify.Tests/PurifyTest.cs
+++ b/test/PUrify.Tests/PurifyTest.cs
@@ -12,7 +12,7 @@ namespace PUrify.Tests
 {
     public class PurifyTest
     {
-      
+
         public class ThePurifyMethod
         {
             private readonly Uri _uri;
@@ -69,6 +69,13 @@ namespace PUrify.Tests
             {
                 var uri = new Uri("http://www.myapi.com/%2F").Purify();
                 uri.ToString().ShouldEqual("http://www.myapi.com/%2F");
+            }
+
+            [Fact]
+            public void GetHashCodeShouldNotThrow()
+            {
+                var uri = new Uri("http://www.myapi.com").Purify();
+                Assert.DoesNotThrow(() => uri.GetHashCode());
             }
         }
 


### PR DESCRIPTION
This adds mono `latest, 3.12.0 & 3.10.0` CI builds on Travis

https://travis-ci.org/Purify-net/PUrify

It also fixes a GetHashCode issue on mono which we hit with NEST:

elastic/elasticsearch-net/issues/1634